### PR TITLE
Improve accessibility of homepage layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,22 +583,17 @@
             <div class="frame-box-game">
               <div class="text-area">
                 <div class="d-flex us-game-info">
-                  <div class="bread-crumb">
-                    <div class="overwrite-breadcumb">
-                      <div class="d-flex al sp bread-crumb-list">
-                        <div class="d-flex al sp">
-                          <a class="bread-crumb-item" href="/">Home</a>
-                          <span class="bread-crumb-item bread-after"
-                            >StickDefendersUnblocked</span
-                          >
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                  <nav class="breadcrumb-trail" aria-label="Breadcrumb">
+                    <ol>
+                      <li><a href="/">Home</a></li>
+                      <li><a href="/categogy/Other.html">All Games</a></li>
+                      <li aria-current="page">Stick Defenders Unblocked</li>
+                    </ol>
+                  </nav>
                 </div>
-                               <!-- text-content start -->
+                <!-- text-content start -->
                 <div id="content-container">
-                  <h1>Stick Defenders Unblocked</h1>
+                  <h2>Stick Defenders Unblocked Overview</h2>
                   <p class="lead">StickDefendersUnblocked brings the stickman defense craze straight to your browser with lightning-fast loading, fullscreen support, and a library of curated extras.</p>
                   <h2>How to Play Stick Defenders</h2>
                   <ul>
@@ -621,6 +616,57 @@
 
     <!--END GAME PLAY-->
     <footer>
+      <div class="site-footer">
+        <div class="footer-grid">
+          <div class="footer-column">
+            <a class="footer-logo" href="/">StickDefendersUnblocked</a>
+            <p class="footer-text">
+              Play classroom-safe browser games without downloads and discover new unblocked hits every week.
+            </p>
+          </div>
+          <div class="footer-column">
+            <h2>Popular Categories</h2>
+            <ul>
+              <li><a href="/categogy/New.html">New Releases</a></li>
+              <li><a href="/categogy/Car.html">Racing Games</a></li>
+              <li><a href="/categogy/Shotting.html">Shooting Games</a></li>
+              <li><a href="/categogy/Sport.html">Sports Games</a></li>
+            </ul>
+          </div>
+          <div class="footer-column">
+            <h2>Player Resources</h2>
+            <ul>
+              <li><a href="/sitemap.xml">XML Sitemap</a></li>
+              <li><a href="/sitemap.txt">Plain Sitemap</a></li>
+              <li><a href="/robots.txt">Robots.txt</a></li>
+              <li>
+                <a
+                  href="https://github.com/stickdefendersunblocked/stickdefendersunblocked.github.io/issues"
+                  target="_blank"
+                  rel="noopener"
+                  >Request a Game</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div class="footer-column">
+            <h2>Stay Updated</h2>
+            <p class="footer-text">
+              Bookmark this hub or follow our GitHub project to get notified when new unblocked games go live.
+            </p>
+            <a
+              class="footer-cta"
+              href="https://github.com/stickdefendersunblocked/stickdefendersunblocked.github.io"
+              target="_blank"
+              rel="noopener"
+              >Follow on GitHub</a
+            >
+          </div>
+        </div>
+        <div class="footer-meta">
+          <p>© 2025 StickDefendersUnblocked. Curated browser games for students and office breaks.</p>
+        </div>
+      </div>
       <script src="/rs/js/jquery-3.4.1.min.js"></script>
       <script src="/rs/js/footer.js"></script>
     </footer>

--- a/rs/css/all.css
+++ b/rs/css/all.css
@@ -579,14 +579,13 @@ header {
 }
 
 .logo-text {
-    color: #fff;
-    text-shadow: 0 0 1px #fff, -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+    color: #0f172a;
+    text-shadow: none;
     letter-spacing: 2px;
     font-size: 1.5rem;
     text-transform: uppercase;
-    font-weight: bold;
-    /* filter: drop-shadow(0 0 1px #0457a7) drop-shadow(1px 1px 0 #0457a7) drop-shadow(-1px 1px 0 #0457a7) drop-shadow(1px -1px 0 #0457a7)drop-shadow(-1px -1px 0 #0457a7); */
-    filter: drop-shadow(0 0 3px #0457a7) drop-shadow(3px 3px 0 #0457a7) drop-shadow(-3px 3px 0 #0457a7) drop-shadow(3px -3px 0 #0457a7)drop-shadow(-3px -3px 0 #0457a7);
+    font-weight: 800;
+    filter: none;
 }
 
 .navigation>ul {
@@ -599,9 +598,9 @@ header {
 }
 
 .menu-link {
-    color: #fff;
+    color: #0f172a;
     font-weight: 700;
-    text-shadow: 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413, 0 0 4px #941413;
+    text-shadow: none;
     padding: 8px 15px;
     border-radius: 20px;
     font-size: 18px;
@@ -615,8 +614,10 @@ header {
     cursor: pointer;
 }
 
-.menu-link:hover {
-    background-color: #941413;
+.menu-link:hover,
+.menu-link:focus {
+    background-color: rgba(15, 23, 42, 0.12);
+    color: #0f172a;
 }
 
 .search-desktop {
@@ -854,33 +855,81 @@ header {
     z-index: 10;
 }
 
-.text-area h2, .text-area h3, .text-area h4 {
-    text-transform: capitalize;
-    font-weight: 600;
-}
-
 .text-area {
     max-width: 100%;
     overflow: hidden;
     text-overflow: clip;
-    line-height: 2;
+    line-height: 1.75;
+    background: #f8fafc;
+    color: #0f172a;
+    padding: 2rem;
+    border-radius: 18px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.2);
+    border: 1px solid rgba(226, 232, 240, 0.65);
 }
 
-.text-area ul, .text-area ol {
-    padding-left: 40px;
+.text-area h2,
+.text-area h3,
+.text-area h4 {
+    text-transform: none;
+    font-weight: 700;
+    color: #0f172a;
+    font-family: 'Nunito Sans', sans-serif;
+    margin-top: 1.75rem;
+    margin-bottom: 0.75rem;
 }
 
-.text-area ul, .text-area ol, .text-area li {
+.text-area h2:first-child {
+    margin-top: 0;
+}
+
+.text-area p,
+.text-area li {
+    color: #334155;
+}
+
+.text-area ul,
+.text-area ol {
+    padding-left: 1.25rem;
+    margin-bottom: 1.25rem;
+}
+
+.text-area ul {
     list-style: disc;
 }
 
-.text-area h1, .text-area h2, .text-area h3, .text-areah4, .text-area h5, .text-area h6 {
-    font-weight: bold;
-    font-family: Righteous;
+.text-area ol {
+    list-style: decimal;
+}
+
+.text-area li + li {
+    margin-top: 0.5rem;
+}
+
+.text-area h1,
+.text-area h2,
+.text-area h3,
+.text-area h4,
+.text-area h5,
+.text-area h6 {
+    font-weight: 700;
+    font-family: 'Nunito Sans', sans-serif;
 }
 
 .text-area a {
-    color: #fdfe03;
+    color: #1d4ed8;
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+.text-area a:hover,
+.text-area a:focus {
+    color: #1e40af;
+}
+
+#content-container {
+    max-width: 780px;
+    margin: 0 auto;
 }
 
 .sticker {
@@ -936,6 +985,50 @@ header {
 
 .overwrite-breadcumb .bread-after:last-child {
     cursor: unset;
+}
+
+.breadcrumb-trail {
+    width: 100%;
+}
+
+.breadcrumb-trail ol {
+    list-style: none;
+    margin: 0 0 1.5rem;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.breadcrumb-trail li {
+    display: flex;
+    align-items: center;
+    font-size: 0.95rem;
+    color: #e2e8f0;
+}
+
+.breadcrumb-trail li + li::before {
+    content: "/";
+    margin-right: 0.5rem;
+    color: #cbd5f5;
+}
+
+.breadcrumb-trail a {
+    color: #38bdf8;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.breadcrumb-trail a:hover,
+.breadcrumb-trail a:focus {
+    color: #f8fafc;
+    text-decoration: underline;
+}
+
+.breadcrumb-trail li[aria-current="page"] {
+    font-weight: 700;
+    color: #f8fafc;
 }
 
 .header-game {


### PR DESCRIPTION
## Summary
- replace the breadcrumb markup with an accessible ordered list and correct page labels
- improve header, body copy, and footer readability through higher-contrast colors and typography updates
- inline the site footer markup so it renders even when JavaScript is disabled while keeping existing links intact

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1798af4548323a5072d3d52fbfcdc